### PR TITLE
Fix: Remove unnecessary `.svg` file extension

### DIFF
--- a/app/helpers/inline-svg.js
+++ b/app/helpers/inline-svg.js
@@ -6,7 +6,14 @@ import {
 } from 'ember-inline-svg/utils/general';
 
 export function inlineSvg(path, options) {
-  var svg = Ember.get(SVGs, dottify(path));
+  var jsonPath = dottify(path),
+      svg = Ember.get(SVGs, jsonPath);
+
+  // TODO: Ember.get should return `null`, not `undefined`.
+  // if (svg === null && /\.svg$/.test(path))
+  if (typeof svg === "undefined" && /\.svg$/.test(path))
+    svg = Ember.get(SVGs, jsonPath.slice(0, -4));
+
   Ember.assert("No SVG found for "+path, svg);
 
   var hash  = options.hash || {};

--- a/tests/acceptance/inline-svg-test.js
+++ b/tests/acceptance/inline-svg-test.js
@@ -35,3 +35,11 @@ test('adds class to SVG', function() {
     ok(find(".kiwi-image-in-directory svg.with-a-class").length, "has added the class");
   });
 });
+
+test('trims unnecessary .svg` extension', function() {
+  visit('/');
+
+  andThen(function() {
+    ok(find(".kiwi-image-with-extension svg").length, "has an SVG");
+  });
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -7,3 +7,7 @@
 <div class="kiwi-image-in-directory">
   {{inline-svg "foo/kiwi" class="with-a-class"}}
 </div>
+
+<div class="kiwi-image-with-extension">
+  {{inline-svg "foo/kiwi.svg"}}
+</div>


### PR DESCRIPTION
Closes #4 for now.

However, I noticed two things while running the tests.

1. Currently the way `aplication.hbs` is set up makes all test cases fail, if the assetion fails for (just) one of them.

2. [`Ember.get`](http://emberjs.com/api/#method_get) doesn't behave as expected. I added a `// TODO:`.

btw, sorry for the "no new line at EOF" fuckery.