### PR TITLE
Fix: Throw error, if SVGO fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 /* jshint node: true */
 'use strict';
 
-var fs            = require('fs');
-var merge         = require('merge')
-var mergeTrees    = require('broccoli-merge-trees');
-var flattenFolder = require('broccoli-spelunk');
-var pickFiles     = require('broccoli-static-compiler');
-var SVGOptmizer   = require('./svg-optimizer');
+var fs          = require('fs');
+var merge       = require('merge')
+var mergeTrees  = require('broccoli-merge-trees');
+var flatiron    = require('broccoli-flatiron');
+var pickFiles   = require('broccoli-static-compiler');
+var SVGOptmizer = require('./svg-optimizer');
 
 module.exports = {
   name: 'ember-inline-svg',
@@ -47,10 +47,9 @@ module.exports = {
 
     svgs = this.optimizeSVGs(svgs);
 
-    svgs = flattenFolder(svgs, {
+    svgs = flatiron(svgs, {
       outputFile: 'svgs.js',
-      mode: 'es6',
-      keepExtensions: false
+      trimExtensions: true
     });
 
     return this.mergeTrees([tree, svgs]);

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var fs          = require('fs');
 var merge       = require('merge')
 var mergeTrees  = require('broccoli-merge-trees');
 var flatiron    = require('broccoli-flatiron');
-var pickFiles   = require('broccoli-static-compiler');
+var Funnel      = require('broccoli-funnel');
 var SVGOptmizer = require('./svg-optimizer');
 
 module.exports = {
@@ -39,10 +39,8 @@ module.exports = {
       return fs.existsSync(path);
     }));
 
-    svgs = pickFiles(svgs, {
-      srcDir: '/',
-      files: ['**/*.svg'],
-      destDir: '/'
+    svgs = new Funnel(svgs, {
+      include: [new RegExp(/\.svg$/)]
     });
 
     svgs = this.optimizeSVGs(svgs);

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "broccoli-caching-writer": "^0.5.2",
     "broccoli-merge-trees": "^0.2.1",
-    "broccoli-spelunk": "^0.1.2",
+    "broccoli-flatiron": "^0.0.0",
     "broccoli-static-compiler": "^0.2.1",
     "merge": "^1.2.0",
     "mkdirp": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "broccoli-caching-writer": "^0.5.2",
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-flatiron": "^0.0.0",
-    "broccoli-static-compiler": "^0.2.1",
+    "broccoli-funnel": "^0.1.7",
     "merge": "^1.2.0",
     "mkdirp": "^0.5.0",
     "promise-map-series": "^0.2.0",

--- a/svg-optimizer.js
+++ b/svg-optimizer.js
@@ -29,6 +29,12 @@ module.exports = CachingWriter.extend({
 
           return new RSVP.Promise(function(resolve, reject) {
             svgo.optimize(rawSVG, function(result) {
+              if (result.error) {
+                var error = new Error(result.error);
+                error.file = relativePath;
+                return reject(error);
+              }
+
               fs.writeFileSync(destPath, result.data, { encoding: 'utf8'});
               resolve();
             });


### PR DESCRIPTION
If an SVG optimization fails, we get a nice descriptive error that even tells us which image caused the error. Sweet.

This closes #3.

I replaced `broccoli-spelunk` with a custom-made plugin: [`broccoli-flatiron`](https://github.com/buschtoens/broccoli-flatiron). Catchy name.
  It basically does, what spelunk has done, but correctly and without all the fuss.