### PR TITLE
Nested Addon Usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,14 @@ var SVGOptmizer = require('./svg-optimizer');
 
 module.exports = {
   name: 'ember-inline-svg',
-
+  
+  included: function(app) {
+    if (app.app) {
+      app = app.app;
+    }
+    this.app = app;
+  },
+  
   options: function() {
     return merge(true, {}, {
       paths:   ['public'],


### PR DESCRIPTION
Hey there,

We've been trying to use `ember-inline-svg` as a nested addon but came across an issue of `app` not being passed correctly. There is a discussion on ember-cli about it but at the moment it seems that there are only work arounds https://github.com/ember-cli/ember-cli/issues/3718

This is a small fix which sets app through the included hook.