### PR TITLE
use `Ember.String.htmlSafe` to remove warning

### DIFF
--- a/app/helpers/inline-svg.js
+++ b/app/helpers/inline-svg.js
@@ -19,7 +19,7 @@ export function inlineSvg(path, options) {
 
   svg = applyClass(svg, options.class);
 
-  return new Ember.Handlebars.SafeString(svg);
+  return Ember.String.htmlSafe(svg);
 }
 
 let helper;


### PR DESCRIPTION
This prevents dev-time warnings such as:

<img width="1042" alt="screen shot 2016-08-15 at 12 15 57" src="https://cloud.githubusercontent.com/assets/2526/17663142/3fc38f0e-62e2-11e6-9034-635573b85f47.png">
