### PR TITLE
remove any leading slashes from paths before dottify-ing

### DIFF
--- a/addon/utils/general.js
+++ b/addon/utils/general.js
@@ -1,7 +1,7 @@
 // converts slash paths to dot paths so nested hash values can be fetched with Ember.get
 // foo/bar/baz -> foo.bar.baz
 export function dottify(path) {
-  return (path || '').replace(/\//g, '.');
+  return (path || '').replace(/^\//g, '').replace(/\//g, '.');
 }
 
 // maybe this should be a component with tagName: 'svg' and strip the outer <svg> tag

--- a/tests/unit/utils/general-test.js
+++ b/tests/unit/utils/general-test.js
@@ -11,6 +11,10 @@ test('replaces slashes with dots', function(assert) {
   assert.equal(dottify("foo/bar/baz"), "foo.bar.baz");
 });
 
+test('removes leading slashes before replacing slashes with dots', function(assert) {
+  assert.equal(dottify("/foo/bar/baz"), "foo.bar.baz");
+});
+
 module('utils: applyClass');
 
 test('adds class to svg element', function(assert) {


### PR DESCRIPTION
[Changes](https://github.com/emberjs/ember.js/issues/14386) in the latest ember 2.9 beta can cause this addon to blowup if you pass in a path like `/images/image-name` because `Ember.get()` will no longer resolve `.images.image-name`.  

This PR makes it so that in the event a path with a leading slash is passed in it will first remove the slash so that `Ember.get()` is called on `images.image-name`.