### PR TITLE
uses regex to avoid overwriting existing class

### DIFF
--- a/addon/utils/general.js
+++ b/addon/utils/general.js
@@ -10,5 +10,12 @@ export function applyClass(svg, klass) {
   if (!klass) { return svg; }
 
   // now we have 2 problems...
+  const regex = /(<svg.*)( class=['"]([^'"]+))['"](.*>)/;
+  const matches = svg.match(regex);
+
+  if (matches) {
+    return matches[1] + ' class="' + klass + ' ' + matches[3] + '"' + matches[4];
+  }
+
   return svg.replace('<svg', '<svg class="'+klass+'"');
 }

--- a/tests/unit/utils/general-test.js
+++ b/tests/unit/utils/general-test.js
@@ -22,3 +22,10 @@ test('adds class to svg element', function(assert) {
   assert.equal(applyClass('<svg width="100"></svg>', 'a-class'), '<svg class="a-class" width="100"></svg>');
   assert.equal(applyClass('<svg></svg>', null), '<svg></svg>');
 });
+
+test('does not erase existing class from svg element', function(assert) {
+  assert.equal(applyClass('<svg class="existing-class"></svg>', null), '<svg class="existing-class"></svg>');
+  assert.equal(applyClass('<svg class="existing-class"></svg>', 'a-class'), '<svg class="a-class existing-class"></svg>');
+  assert.equal(applyClass('<svg width="100" class="existing-class"></svg>', 'a-class'), '<svg width="100" class="a-class existing-class"></svg>');
+  assert.equal(applyClass('<svg class="another-existing-class" height="100"></svg>', 'a-class'), '<svg class="a-class another-existing-class" height="100"></svg>');
+});


### PR DESCRIPTION
I saw that there was some talk around turning the SVG into a component to accept attributes passed to it. I had a problem where setting a class with the `inline-svg` helper would overwrite any existing classes on the SVG element, so I came up with this quick solution using a regex.

Probably not worth merging if you're planning on componentizing the helper, but here ya go.

A similar solution could be used for setting other attributes. Would be happy to work on contributing to that if needed.