### PR TITLE
Update dependencies to latest versions and turn into plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = {
       return tree;
     }
 
-    return new SVGOptmizer(tree, {svgoConfig: config});
+    return new SVGOptmizer([tree], {svgoConfig: config});
   },
 
   treeForApp: function(tree) {

--- a/package.json
+++ b/package.json
@@ -45,17 +45,17 @@
     "svg"
   ],
   "dependencies": {
-    "broccoli-caching-writer": "^0.5.5",
+    "broccoli-caching-writer": "^3.0.3",
     "broccoli-flatiron": "0.0.0",
     "broccoli-funnel": "^1.0.1",
-    "broccoli-merge-trees": "^1.1.1",
+    "broccoli-merge-trees": "^2.0.0",
     "ember-cli-babel": "^5.1.6",
     "merge": "^1.2.0",
     "mkdirp": "^0.5.1",
     "promise-map-series": "^0.2.1",
     "rsvp": "^3.2.1",
     "svgo": "^0.6.3",
-    "walk-sync": "^0.1.3"
+    "walk-sync": "^0.3.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/svg-optimizer.js
+++ b/svg-optimizer.js
@@ -1,6 +1,6 @@
 /* jshint node: true */
 
-var CachingWriter = require('broccoli-caching-writer');
+var Plugin        = require('broccoli-caching-writer');
 var mapSeries     = require('promise-map-series');
 var walkSync      = require('walk-sync');
 var mkdirp        = require('mkdirp');
@@ -9,39 +9,50 @@ var SVGO          = require('svgo');
 var RSVP          = require('rsvp');
 var fs            = require('fs');
 
-// TODO - extract this to its own broccoli plugin
-module.exports = CachingWriter.extend({
-  updateCache: function(srcDirs, destDir) {
-    var svgo = new SVGO(this.svgoConfig);
 
-    return mapSeries(srcDirs, function(srcDir) {
-      var paths = walkSync(srcDir);
+SVGOptimizer.prototype = Object.create(Plugin.prototype);
+SVGOptimizer.prototype.constructor = SVGOptimizer;
+function SVGOptimizer(inputNodes, options) {
+  options = options || {};
+  Plugin.call(this, inputNodes, {
+    annotation: options.annotation,
+    cacheInclude: [/\.svg/]
+  });
+}
 
-      return mapSeries(paths, function(relativePath) {
-        if (/\/$/.test(relativePath)) {
-          mkdirp.sync(destDir + '/' + relativePath);
-          return;
-        }
+SVGOptimizer.prototype.build = function() {
+  var svgo = new SVGO(this.svgoConfig);
+  var destDir = this.outputPath;
 
-        if (/\.svg$/.test(relativePath)) {
-          var srcPath  = path.join(srcDir, relativePath);
-          var destPath = path.join(destDir, relativePath);
-          var rawSVG   = fs.readFileSync(srcPath, { encoding: 'utf8' });
+  return mapSeries(this.inputPaths, function(srcDir) {
+    var paths = walkSync(srcDir);
 
-          return new RSVP.Promise(function(resolve, reject) {
-            svgo.optimize(rawSVG, function(result) {
-              if (result.error) {
-                var error = new Error(result.error);
-                error.file = relativePath;
-                return reject(error);
-              }
+    return mapSeries(paths, function(relativePath) {
+      if (/\/$/.test(relativePath)) {
+        mkdirp.sync(destDir + '/' + relativePath);
+        return;
+      }
 
-              fs.writeFileSync(destPath, result.data, { encoding: 'utf8'});
-              resolve();
-            });
+      if (/\.svg$/.test(relativePath)) {
+        var srcPath  = path.join(srcDir, relativePath);
+        var destPath = path.join(destDir, relativePath);
+        var rawSVG   = fs.readFileSync(srcPath, { encoding: 'utf8' });
+
+        return new RSVP.Promise(function(resolve, reject) {
+          svgo.optimize(rawSVG, function(result) {
+            if (result.error) {
+              var error = new Error(result.error);
+              error.file = relativePath;
+              return reject(error);
+            }
+
+            fs.writeFileSync(destPath, result.data, { encoding: 'utf8'});
+            resolve();
           });
-        }
-      });
+        });
+      }
     });
-  }
-});
+  });
+};
+
+module.exports = SVGOptimizer;


### PR DESCRIPTION
The [ember-cli performance guide](https://github.com/ember-cli/ember-cli/blob/master/PERF_GUIDE.md) has some suggestions for speeding up apps. One of the suggestions is to ensure that your app doesn't reference `broccoli-caching-writer` < `2.2.1`.

When I ran the `npm ls` command against one of our apps I noticed that `ember-inline-svg` was pulling in `broccoli-caching-writer@0.5.5`.

This PR updates the `broccoli-*` modules to the latest released versions and updates `svg-optimizer.js` to the `Plugin` pattern used by the new `broccoli-caching-writer`.