### PR TITLE
Add installation command to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Displays SVG images inline.
 
+## Installation
+```bash
+ember install ember-inline-svg
+```
+
 ## Usage
 
 ```handlebars


### PR DESCRIPTION
People normally expect to find installation commands or steps at the top of a README file.
This one didn't have it, so I added it.
Just so it could be a copy-pasted from here.