### PR TITLE
chore: update svgo dependency supported version

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mkdirp": "^0.5.1",
     "promise-map-series": "^0.2.1",
     "rsvp": "^3.2.1",
-    "svgo": "^0.6.3",
+    "svgo": ">=0.6.3",
     "walk-sync": "^0.3.1"
   },
   "ember-addon": {


### PR DESCRIPTION
The current SVGO version is 2 year old and is missing a lot of new bug fixes, features and plugins provided in the latest version. Because no breaking change were introduced in the new versions, `ember-inline-svg` supports all new versions of `svgo`.

### Changes:
* change version compatibility of `svgo` in `package.json` to support all versions >= 0.6.3.

### References
* Closes issue https://github.com/minutebase/ember-inline-svg/issues/51
* See David-dm reports:  [![devDependencies Status](https://david-dm.org/minutebase/ember-inline-svg/dev-status.svg)](https://david-dm.org/minutebase/ember-inline-svg?type=dev) [![dependencies Status](https://david-dm.org/minutebase/ember-inline-svg/status.svg)](https://david-dm.org/minutebase/ember-inline-svg) 

You could also run `david update` using the [David CLI](https://www.npmjs.com/package/david).

Poke @minutebase @rlivsey 
