### PR TITLE
Bump broccoli-flatiron to 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "broccoli-caching-writer": "^3.0.3",
-    "broccoli-flatiron": "0.0.0",
+    "broccoli-flatiron": "^0.1.2",
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^2.0.0",
     "ember-cli-babel": "^5.1.6",


### PR DESCRIPTION
```
// versions
ember-cli: 2.16.2
ember-inline-svg: 0.1.11

// config
svg: {
  optimize: false
}
```

On trying to disable optimization in `ember-inline-svg` I kept getting 
```
EISDIR: illegal operation on a directory, read
```
from within `broccoili-flatiron`. It appears when optimization is turned off some directories are actually symlinks and `broccoli-flatiron`'s use of `fs.lstatSync` returns `false` causing it to treat it as a file. broccoli-flatiron 0.1.2 contains [a fix for iterating over symlinked directories](https://github.com/buschtoens/broccoli-flatiron/pull/2) by replacing `fs.lstatSync` with `fs.statSync`.

Optimization enabled
<img width="645" alt="screen shot 2018-06-27 at 08 44 31" src="https://user-images.githubusercontent.com/685034/41961966-ce45ca72-79eb-11e8-8c13-bdd89b5a7c7d.png">

Optimization disabled
<img width="669" alt="screen shot 2018-06-27 at 08 49 00" src="https://user-images.githubusercontent.com/685034/41961968-ce69e2c2-79eb-11e8-9ffc-2eeb5d9e568f.png">