### PR TITLE
Update htmlSafe call to 'ember/string'

### DIFF
--- a/addon/helpers/inline-svg.js
+++ b/addon/helpers/inline-svg.js
@@ -1,4 +1,4 @@
-import { htmlSafe } from '@ember/template';
+import { htmlSafe } from '@ember/string';
 import { assert } from '@ember/debug';
 import { get } from '@ember/object';
 


### PR DESCRIPTION
According to this: https://www.emberjs.com/api/ember/3.3/functions/@ember%2Ftemplate/htmlSafe
The current import doesn't work for me in Ember v2.18.2
No idea how it works for anyone else. Maybe in Ember v3+ this works.