### PR TITLE
[FEATURE] 🛠 Add/Update <title> to SVG markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ You can specify a class for the element like so:
 {{inline-svg "my-svg" class="foo"}}
 ```
 
+Also, you can add/update `<title></title>` by doing:
+
+```handlebars
+{{inline-svg 'mySVG' title="myTitle'}}
+{{inline-svg 'mySVG' class="myClass" title="myTitle'}}
+```
+
 ## Configuring
 
 ### SVG Paths

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ var app = new EmberApp({
 });
 ```
 
-Alternatively, you can disable it completely by setting this to false:
+Please bear in mind that but default we are stripping `title` from any svg with `removeTitle: true`, you can
+disable it with `removeTitle: false` or alternatively, you can disable every optimization  by doing:
 
 ```javascript
 var app = new EmberApp({

--- a/addon/helpers/inline-svg.js
+++ b/addon/helpers/inline-svg.js
@@ -4,7 +4,8 @@ import { get } from '@ember/object';
 
 import {
   dottify,
-  applyClass
+  applyClass,
+  applyTitle
 } from 'ember-inline-svg/utils/general';
 
 export function inlineSvg(svgs, path, options) {
@@ -20,6 +21,7 @@ export function inlineSvg(svgs, path, options) {
   assert("No SVG found for "+path, svg);
 
   svg = applyClass(svg, options.class);
+  svg = applyTitle(svg, options.title)
 
   return htmlSafe(svg);
 }

--- a/addon/utils/general.js
+++ b/addon/utils/general.js
@@ -17,7 +17,7 @@ export function applyClass(svg, klass) {
 export function applyTitle(svg, title) {
   if (!title) { return svg; }
 
-  if (svg.includes('<title>')) {
+  if (svg.indexOf('<title>') !== -1) {
     return svg.replace(/<title>(.*?)<\/title>/gm, `<title>${title}</title>`);
   } else {
     return svg.replace('</svg>', `<title>${title}</title></svg>`);

--- a/addon/utils/general.js
+++ b/addon/utils/general.js
@@ -17,7 +17,7 @@ export function applyClass(svg, klass) {
 export function applyTitle(svg, title) {
   if (!title) { return svg; }
 
-  if (svg.includes('title')) {
+  if (svg.includes('<title>')) {
     return svg.replace(/<title>(.*?)<\/title>/gm, `<title>${title}</title>`);
   } else {
     return svg.replace('</svg>', `<title>${title}</title></svg>`);

--- a/addon/utils/general.js
+++ b/addon/utils/general.js
@@ -12,3 +12,14 @@ export function applyClass(svg, klass) {
   // now we have 2 problems...
   return svg.replace('<svg', '<svg class="'+klass+'"');
 }
+
+// add/update title to svg
+export function applyTitle(svg, title) {
+  if (!title) { return svg; }
+
+  if (svg.includes('title')) {
+    return svg.replace(/<title>(.*?)<\/title>/gm, `<title>${title}</title>`);
+  } else {
+    return svg.replace('</svg>', `<title>${title}</title></svg>`);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^3.0.0",
     "ember-cli-babel": "^6.16.0",
-    "merge": "^1.2.0",
+    "merge": "^1.2.1",
     "mkdirp": "^0.5.1",
     "promise-map-series": "^0.2.1",
     "svgo": "~1.0.5",

--- a/tests/acceptance/inline-svg-test.js
+++ b/tests/acceptance/inline-svg-test.js
@@ -23,6 +23,11 @@ module('Acceptance | inline-svg', function(hooks) {
     assert.ok(find(".kiwi-image-with-a-class svg.with-a-class"), "has added the class");
   });
 
+  test('adds/update title to SVG', async function (assert) {
+    await visit('/title');
+    assert.equal(find("title").textContent, "with-a-title", "has added title");
+  });
+
   test('trims unnecessary .svg` extension', async function(assert) {
     await visit('/extension');
 

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -11,6 +11,7 @@ Router.map(function() {
   this.route("subdirectory");
   this.route("class");
   this.route("extension");
+  this.route("title");
 });
 
 export default Router;

--- a/tests/dummy/app/templates/title.hbs
+++ b/tests/dummy/app/templates/title.hbs
@@ -1,0 +1,5 @@
+<h1>Title</h1>
+
+<div class="kiwi-image-with-a-title">
+  {{inline-svg "kiwi" class="with-a-class" title="with-a-title"}}
+</div>

--- a/tests/unit/utils/general-test.js
+++ b/tests/unit/utils/general-test.js
@@ -1,6 +1,7 @@
 import {
   dottify,
-  applyClass
+  applyClass,
+  applyTitle
 } from 'ember-inline-svg/utils/general';
 
 import {module, test} from 'qunit';
@@ -21,4 +22,13 @@ test('adds class to svg element', function(assert) {
   assert.equal(applyClass('<svg></svg>', 'a-class'), '<svg class="a-class"></svg>');
   assert.equal(applyClass('<svg width="100"></svg>', 'a-class'), '<svg class="a-class" width="100"></svg>');
   assert.equal(applyClass('<svg></svg>', null), '<svg></svg>');
+});
+
+module('utils: applyTitle');
+
+test('adds/updates title to svg element', function(assert) {
+  assert.equal(applyTitle('<svg></svg>', 'svgTitle'), '<svg><title>svgTitle</title></svg>');
+  assert.equal(applyTitle('<svg width="100"></svg>', 'svgTitle'), '<svg width="100"><title>svgTitle</title></svg>');
+  assert.equal(applyTitle('<svg><title>Original Title</title></svg>', 'New Title'), '<svg><title>New Title</title></svg>');
+  assert.equal(applyTitle('<svg></svg>', null), '<svg></svg>');
 });

--- a/tests/unit/utils/general-test.js
+++ b/tests/unit/utils/general-test.js
@@ -28,7 +28,8 @@ module('utils: applyTitle');
 
 test('adds/updates title to svg element', function(assert) {
   assert.equal(applyTitle('<svg></svg>', 'svgTitle'), '<svg><title>svgTitle</title></svg>');
-  assert.equal(applyTitle('<svg width="100"></svg>', 'svgTitle'), '<svg width="100"><title>svgTitle</title></svg>');
+  assert.equal(applyTitle("<svg width='100'></svg>", 'svgTitle'), "<svg width='100'><title>svgTitle</title></svg>");
   assert.equal(applyTitle('<svg><title>Original Title</title></svg>', 'New Title'), '<svg><title>New Title</title></svg>');
   assert.equal(applyTitle('<svg></svg>', null), '<svg></svg>');
+  assert.equal(applyTitle("<svg class='title'></svg>", 'svgTitle'), "<svg class='title'><title>svgTitle</title></svg>");
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4308,6 +4308,11 @@ merge@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
+merge@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
+  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
+
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"


### PR DESCRIPTION
Hi all,

Thanks for this awesome addon.

With this PR we'll have the option of `adding/updating` `<title>` to any svg. This new feature allows to:
- Add a new `<title>Title text</title>` when user passes something like 
```html
{{inline-svg 'mySVG' title="myTitle'}}
{{inline-svg 'mySVG' class="myClass" title="myTitle'}}
```
- Updates any previous `<title>Original Title text</title>` with `<title>New Title text</title>`, same call than before can be used.
```html
{{inline-svg 'mySVG' title="New Title text'}}
{{inline-svg 'mySVG' class="myClass" title="New Title text'}}
```