### PR TITLE
Remove deprecation warnings

### DIFF
--- a/addon/helpers/inline-svg.js
+++ b/addon/helpers/inline-svg.js
@@ -1,4 +1,4 @@
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import { assert } from '@ember/debug';
 import { get } from '@ember/object';
 


### PR DESCRIPTION
Import `htmlSafe` from `@ember/string` is deprecated:

https://deprecations.emberjs.com/v3.x#toc_ember-string-htmlsafe-ishtmlsafe

This PR just replace the import to be from `@ember/template` and, in that way, remove the displayed deprecation warning.